### PR TITLE
Update xprv xpub

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,4 +10,6 @@ Slush - Work on the server. Designed the original Stratum spec.
 Julian Toash (Tuxavant) - Various fixes to the client.
 rdymac - Website and translations.
 kyuupichan - Miscellaneous.
-pooler - Garlicoin port.
+pooler - Litecoin port.
+xSke - Garlium v3
+Kryptonite - Garlium v2 & v4

--- a/README.rst
+++ b/README.rst
@@ -7,9 +7,9 @@ Electrum-GRLC is a port of Electrum, the Bitcoin wallet, to Garlicoin.
 
   Licence: MIT Licence
   Original Author: Thomas Voegtlin
-  Port Maintainer: Pooler
+  Port Maintainer: Ryan Shaw
   Language: Python (>= 3.6)
-  Homepage: https://electrum-grlc.org/
+  Homepage: https://www.github.com/garlicoin-project
 
 
 
@@ -21,7 +21,7 @@ Getting started
 
 (*If you've come here looking to simply run Electrum,* `you may download it here`_.)
 
-.. _you may download it here: https://electrum-grlc.org/#download
+.. _you may download it here: https://github.com/garlicoin-project/garlium-new/releases
 
 Electrum-GRLC itself is pure Python, and so are most of the required dependencies,
 but not everything. The following sections describe how to run from source, but here
@@ -87,7 +87,7 @@ Development version (git clone)
 
 Check out the code from GitHub::
 
-    git clone git://github.com/pooler/electrum-grlc.git
+    git clone https://github.com/garlicoin-project/garlium-new.git
     cd electrum-grlc
     git submodule update --init
 
@@ -149,10 +149,11 @@ Implementing new features, or improving/refactoring the codebase, is of course
 also welcome, but to avoid wasted effort, especially for larger changes,
 we encourage discussing these on the issue tracker or IRC first.
 
-Besides `GitHub`_, some communication about Electrum-GRLC development happens on IRC, in the
-:code:`#electrum-grlc` channel on Libera Chat. The easiest way to participate on IRC is
-with the web client, `web.libera.chat`_.
+Besides `GitHub`_, some communication about Electrum-GRLC development happens on Discord, in the
+:code:`#public-dev` channel on GRLC'cord. The easiest way to participate on IRC is
+with the web client, `_web.discord_public_dev`_.
 
 
-.. _web.libera.chat: https://web.libera.chat/#electrum-grlc
-.. _GitHub: https://github.com/pooler/electrum-grlc
+.. _web.discord_public_dev: https://discord.gg/XDVbGVRkwx
+.. _GitHub: https://github.com/garlicoin-project/garlium-new
+

--- a/electrum_grlc/constants.py
+++ b/electrum_grlc/constants.py
@@ -84,7 +84,7 @@ class BitcoinMainnet(AbstractNet):
     BLOCK_HEIGHT_FIRST_LIGHTNING_CHANNELS = 9999999999999
 
     XPRV_HEADERS = {
-        'standard':    0x019da462,  # tprv
+        'standard':    0x0488ade4,  # tprv
         'p2wpkh-p2sh': 0x049d7878,  # uprv
         'p2wsh-p2sh':  0x0295b005,  # Uprv
         'p2wpkh':      0x04b2430c,  # vprv
@@ -92,7 +92,7 @@ class BitcoinMainnet(AbstractNet):
     }
     XPRV_HEADERS_INV = inv_dict(XPRV_HEADERS)
     XPUB_HEADERS = {
-        'standard':    0x019d9cfe,  # xpub
+        'standard':    0x0488b21e,  # xpub
         'p2wpkh-p2sh': 0x049d7cb2,  # ypub
         'p2wsh-p2sh':  0x0295b43f,  # Ypub
         'p2wpkh':      0x04b24746,  # zpub


### PR DESCRIPTION
Meant to do this as two separate PRs - 

Litecoin Electrum briefly used 0x019da462 and 0x019d9cfe as the xprv & xpub values, but they were never officially adopted by Litecoin.  They've reverted to using 0x0488ade4 & 0x0488b21e, the same as Bitcoin, and in line with the values from Core.