### PR TITLE
Update Garlicoin cointype

### DIFF
--- a/electrum_grlc/constants.py
+++ b/electrum_grlc/constants.py
@@ -99,7 +99,7 @@ class BitcoinMainnet(AbstractNet):
         'p2wsh':       0x02aa7ed3,  # Zpub
     }
     XPUB_HEADERS_INV = inv_dict(XPUB_HEADERS)
-    BIP44_COIN_TYPE = 2
+    BIP44_COIN_TYPE = 69420
     LN_REALM_BYTE = 0
     LN_DNS_SEEDS = []
 


### PR DESCRIPTION
Garlicoin is now cointype 69420 per https://github.com/satoshilabs/slips/blob/master/slip-0044.md.  With the addition of the "find accounts" feature on wallet import, we can likely safely make this change without too much disruption to users.